### PR TITLE
fix: prepare version workflow for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,3 +98,17 @@ jobs:
           else
             pnpm exec jsr publish
           fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "GitHub release v${VERSION} already exists"
+          else
+            gh release create "v${VERSION}" \
+              --verify-tag \
+              --generate-notes \
+              --title "v${VERSION}"
+          fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The project is published under different registry names for compatibility:
 
 ## Run it
 
+Requires Node.js 22 or newer.
+
 Run the npm package without installing it:
 
 ```bash

--- a/tests/basicBehavior.test.ts
+++ b/tests/basicBehavior.test.ts
@@ -42,7 +42,10 @@ describe("Basic Behavior", () => {
 	});
 
 	it("should report the package version", async () => {
+		const {version} = JSON.parse(
+			await fs.readFile(new URL("../package.json", import.meta.url), "utf8"),
+		) as {version: string};
 		const {stdout} = await runCLI("--version");
-		expect(stdout.trim()).toBe("1.11.0");
+		expect(stdout.trim()).toBe(version);
 	});
 });


### PR DESCRIPTION
## Summary
- make the CLI version test follow package.json so version PRs remain green
- document the Node.js 22 runtime requirement
- create an idempotent GitHub Release with generated notes after registry publishing succeeds

## Verification
- pnpm validate
- pnpm pack --dry-run
- isolated pnpm version major --no-git-tag-version rehearsal (2.0.0)
- isolated 2.0.0 pnpm validate and pnpm pack --dry-run