### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@slpixe/ai-md",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-txt",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "description": "CLI tool to aggregate files into a single Markdown file",
   "main": "dist/cli.js",
   "type": "module",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Kept in sync with package.json by scripts/sync-version.js.
-export const VERSION = '1.11.0';
+export const VERSION = '2.0.0';


### PR DESCRIPTION
Automated version update for v2.0.0. Merge after all required checks pass; publishing starts from the protected release environment.

This is a major release because the supported Node.js runtime is now Node.js 22 or newer.